### PR TITLE
Handling accounts with multiple emails

### DIFF
--- a/lib/ueberauth/strategy/fastmail/caldav.ex
+++ b/lib/ueberauth/strategy/fastmail/caldav.ex
@@ -7,7 +7,7 @@ defmodule Ueberauth.Strategy.Fastmail.CalDAV do
   import SweetXml
 
   @current_user_principal_xpath ~x"//d:multistatus/d:response/d:propstat/d:prop/d:current-user-principal/d:href/text()"s
-  @current_user_email_xpath ~x"//d:multistatus/d:response/d:propstat/d:prop/c:calendar-user-address-set/d:href/text()"s
+  @current_user_email_xpath ~x"//d:multistatus/d:response/d:propstat/d:prop/c:calendar-user-address-set/d:href[position()=last()]/text()"s
   @current_user_displayname_xpath ~x"//d:multistatus/d:response/d:propstat/d:prop/d:displayname/text()"s
 
   @doc """


### PR DESCRIPTION
Some accounts are coming through SSO with multiple emails and because we're not specific enough with our XPath, it's just concatenating all those email addresses together.

Per a discussion with Fastmail (who said the last address should always be the default) we've updated the XPath to only select the email where `[position()=last()]`.